### PR TITLE
feat(dashboard): connect dashboard to Supabase data

### DIFF
--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getAuthContext } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+
+export type UserActivityItem = {
+  id: string
+  name: string
+  description: string | null
+  category: string
+  durationMinutes: number | null
+  points: number
+  type: 'positive' | 'treat'
+}
+
+export async function GET() {
+  const auth = await getAuthContext()
+
+  if (!auth.isConfigured) {
+    return NextResponse.json({ error: 'Supabase not configured', code: 'supabase_not_configured' }, { status: 503 })
+  }
+
+  if (!auth.profile) {
+    return NextResponse.json({ error: 'Unauthorized', code: 'unauthorized' }, { status: 401 })
+  }
+
+  const client = await createClient()
+  const [activitiesResult, rewardsResult] = await Promise.all([
+    client
+      .from('user_activities')
+      .select('id, name, description, category, duration_minutes, points')
+      .eq('profile_id', auth.profile.id)
+      .eq('status', 'active')
+      .order('points', { ascending: false }),
+    client
+      .from('rewards')
+      .select('id, name, description, category, duration_minutes, cost_points')
+      .eq('profile_id', auth.profile.id)
+      .eq('status', 'active')
+      .order('cost_points', { ascending: false }),
+  ])
+
+  if (activitiesResult.error || rewardsResult.error) {
+    const message = activitiesResult.error?.message ?? rewardsResult.error?.message
+    return NextResponse.json({ error: message, code: 'persistence_error' }, { status: 500 })
+  }
+
+  const activities: UserActivityItem[] = [
+    ...(activitiesResult.data ?? []).map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      category: row.category,
+      durationMinutes: row.duration_minutes,
+      points: row.points,
+      type: 'positive' as const,
+    })),
+    ...(rewardsResult.data ?? []).map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      category: row.category,
+      durationMinutes: row.duration_minutes,
+      points: row.cost_points,
+      type: 'treat' as const,
+    })),
+  ]
+
+  return NextResponse.json(activities)
+}

--- a/app/api/today/complete/route.ts
+++ b/app/api/today/complete/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createHabitQuestDomainService } from '@/lib/ai/habitquest-domain-service'
+import { z } from 'zod'
+
+export const dynamic = 'force-dynamic'
+
+const bodySchema = z.object({
+  planItemId: z.string().uuid(),
+  durationMinutes: z.number().int().positive().optional(),
+  note: z.string().max(500).optional(),
+})
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body', code: 'invalid_input' }, { status: 400 })
+  }
+
+  const parsed = bodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input', code: 'invalid_input' }, { status: 400 })
+  }
+
+  const service = createHabitQuestDomainService()
+  const result = await service.completePlanItem({
+    planItemId: parsed.data.planItemId,
+    durationMinutes: parsed.data.durationMinutes ?? null,
+    note: parsed.data.note ?? null,
+    source: 'web',
+  })
+
+  if (!result.ok) {
+    const status =
+      result.error.code === 'supabase_not_configured'
+        ? 503
+        : result.error.code === 'unauthorized'
+          ? 401
+          : result.error.code === 'not_found'
+            ? 404
+            : result.error.code === 'conflict'
+              ? 409
+              : 500
+
+    return NextResponse.json({ error: result.error.message, code: result.error.code }, { status })
+  }
+
+  return NextResponse.json(result.data)
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,51 @@
 import { AppShell } from '@/components/app-shell'
 import { AuthCard } from '@/components/auth-card'
 import { getAuthContext } from '@/lib/auth'
+import { createHabitQuestDomainService } from '@/lib/ai/habitquest-domain-service'
+import { createClient } from '@/lib/supabase/server'
+import type { TodaySummaryData } from '@/lib/ai/habitquest-domain-service'
+import type { UserActivityItem } from '@/app/api/activities/route'
 
 export const dynamic = 'force-dynamic'
+
+async function fetchUserActivities(profileId: string): Promise<UserActivityItem[]> {
+  const client = await createClient()
+  const [activitiesResult, rewardsResult] = await Promise.all([
+    client
+      .from('user_activities')
+      .select('id, name, description, category, duration_minutes, points')
+      .eq('profile_id', profileId)
+      .eq('status', 'active')
+      .order('points', { ascending: false }),
+    client
+      .from('rewards')
+      .select('id, name, description, category, duration_minutes, cost_points')
+      .eq('profile_id', profileId)
+      .eq('status', 'active')
+      .order('cost_points', { ascending: false }),
+  ])
+
+  return [
+    ...(activitiesResult.data ?? []).map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      category: row.category,
+      durationMinutes: row.duration_minutes,
+      points: row.points,
+      type: 'positive' as const,
+    })),
+    ...(rewardsResult.data ?? []).map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      category: row.category,
+      durationMinutes: row.duration_minutes,
+      points: row.cost_points,
+      type: 'treat' as const,
+    })),
+  ]
+}
 
 export default async function Home() {
   const auth = await getAuthContext()
@@ -11,11 +54,30 @@ export default async function Home() {
     return <AuthCard isConfigured={auth.isConfigured} />
   }
 
+  let initialSummary: TodaySummaryData | null = null
+  let initialActivities: UserActivityItem[] = []
+
+  if (auth.hasCompletedOnboarding) {
+    const service = createHabitQuestDomainService()
+    const [summaryResult, activities] = await Promise.all([
+      service.getTodaySummary(),
+      fetchUserActivities(auth.profile.id),
+    ])
+
+    if (summaryResult.ok) {
+      initialSummary = summaryResult.data
+    }
+
+    initialActivities = activities
+  }
+
   return (
     <AppShell
       profileId={auth.profile.id}
       displayName={auth.profile.display_name ?? auth.user.email ?? 'Demo user'}
       initialHasOnboarded={auth.hasCompletedOnboarding}
+      initialSummary={initialSummary}
+      initialActivities={initialActivities}
     />
   )
 }

--- a/components/activity-card.tsx
+++ b/components/activity-card.tsx
@@ -24,8 +24,8 @@ import {
 
 interface ActivityCardProps {
   activity: Activity
-  isCompleted?: boolean
   completedCount?: number
+  availablePoints?: number
 }
 
 function ActivityIcon({ activity }: { activity: Activity }) {
@@ -45,14 +45,12 @@ function ActivityIcon({ activity }: { activity: Activity }) {
   return <Leaf className={className} />
 }
 
-export function ActivityCard({ activity, completedCount = 0 }: ActivityCardProps) {
+export function ActivityCard({ activity, completedCount = 0, availablePoints = 0 }: ActivityCardProps) {
   const [isAnimating, setIsAnimating] = useState(false)
-  const { completeActivity, canUseTreat, getTodayProgress } = useAppStore()
+  const { completeActivity } = useAppStore()
 
   const isPositive = activity.type === 'positive'
-  const canUse = isPositive || canUseTreat(activity.points)
-  const progress = getTodayProgress()
-  const availablePoints = progress.positivePoints - progress.treatPointsUsed
+  const canUse = isPositive || availablePoints >= activity.points
 
   const handleComplete = () => {
     if (!canUse) return

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -3,19 +3,30 @@
 import { useState } from 'react'
 import { Onboarding } from '@/components/onboarding'
 import { Dashboard } from '@/components/dashboard'
+import type { TodaySummaryData } from '@/lib/ai/habitquest-domain-service'
+import type { UserActivityItem } from '@/app/api/activities/route'
 
 type AppShellProps = {
   profileId: string
   displayName: string
   initialHasOnboarded: boolean
+  initialSummary: TodaySummaryData | null
+  initialActivities: UserActivityItem[]
 }
 
-export function AppShell({ profileId, displayName, initialHasOnboarded }: AppShellProps) {
+export function AppShell({ profileId, displayName, initialHasOnboarded, initialSummary, initialActivities }: AppShellProps) {
   const [hasOnboarded, setHasOnboarded] = useState(initialHasOnboarded)
 
   if (!hasOnboarded) {
     return <Onboarding onCompleted={() => setHasOnboarded(true)} />
   }
 
-  return <Dashboard profileId={profileId} displayName={displayName} />
+  return (
+    <Dashboard
+      profileId={profileId}
+      displayName={displayName}
+      initialSummary={initialSummary}
+      initialActivities={initialActivities}
+    />
+  )
 }

--- a/components/balance-meter.tsx
+++ b/components/balance-meter.tsx
@@ -1,18 +1,19 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { useAppStore } from '@/lib/store'
 import { Card } from '@/components/ui/card'
 import { Flame, Gift, Sparkles, TrendingUp, Zap } from 'lucide-react'
 
-export function BalanceMeter() {
-  const { getTodayProgress, getStreak } = useAppStore()
-  const progress = getTodayProgress()
-  const streak = getStreak()
+type BalanceMeterProps = {
+  availablePoints: number
+  completedPoints: number
+  redeemedPoints: number
+  streak?: number
+}
 
-  const availablePoints = Math.max(0, progress.positivePoints - progress.treatPointsUsed)
-  const totalEarned = progress.positivePoints
-  const totalSpent = progress.treatPointsUsed
+export function BalanceMeter({ availablePoints, completedPoints, redeemedPoints, streak = 0 }: BalanceMeterProps) {
+  const totalEarned = completedPoints
+  const totalSpent = redeemedPoints
   const maxDisplay = Math.max(120, totalEarned + 40)
   const earnedPercent = Math.min(100, (totalEarned / maxDisplay) * 100)
   const spentPercent = Math.min(100, (totalSpent / maxDisplay) * 100)

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,18 +1,19 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useState, useTransition } from 'react'
 import { motion } from 'framer-motion'
 import { useRouter } from 'next/navigation'
 import { BalanceMeter } from './balance-meter'
 import { ActivityCard } from './activity-card'
 import { AddActivityDialog } from './add-activity-dialog'
 import { ChatPanel } from './chat-panel'
-import { useAppStore } from '@/lib/store'
 import { createClient } from '@/lib/supabase/client'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Activity } from '@/lib/types'
+import type { Activity } from '@/lib/types'
+import type { TodaySummaryData } from '@/lib/ai/habitquest-domain-service'
+import type { UserActivityItem } from '@/app/api/activities/route'
 import {
   Bot,
   CalendarCheck,
@@ -34,29 +35,30 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
-type PlannedActivity = {
-  activityId: string
-  label: string
-  note: string
-  activity: Activity
+function toActivityShape(item: UserActivityItem): Activity {
+  return {
+    id: item.id,
+    name: item.name,
+    icon: item.category.toLowerCase(),
+    type: item.type,
+    points: item.points,
+    duration: item.durationMinutes ?? undefined,
+    category: item.category,
+    description: item.description ?? undefined,
+  }
 }
-
-const demoPlan = [
-  { activityId: '6', label: 'Morning light walk', note: 'Start with movement and fresh air.' },
-  { activityId: '3', label: '10 minute meditation', note: 'Lower noise before deep work.' },
-  { activityId: '7', label: 'Reading block', note: 'One calm input before screens.' },
-  { activityId: '10', label: 'Stretch reset', note: 'Small recovery action to close the day.' },
-]
 
 type DashboardProps = {
   profileId: string
   displayName: string
+  initialSummary: TodaySummaryData | null
+  initialActivities: UserActivityItem[]
 }
 
-export function Dashboard({ profileId, displayName }: DashboardProps) {
+export function Dashboard({ profileId, displayName, initialSummary, initialActivities }: DashboardProps) {
   const router = useRouter()
-  const { getTodayProgress, getAllActivities, customActivities, resetDay, completeActivity } = useAppStore()
   const [activeTab, setActiveTab] = useState<'positive' | 'treats'>('positive')
+  const [isPending, startTransition] = useTransition()
 
   const scrollToCoachChat = () => {
     document.getElementById('coach-chat')?.scrollIntoView({
@@ -65,29 +67,24 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
     })
   }
 
-  const progress = getTodayProgress()
-  const allActivities = getAllActivities()
-  const positiveActivities = allActivities.filter((activity) => activity.type === 'positive')
-  const treatActivities = allActivities.filter((activity) => activity.type === 'treat')
-  const availablePoints = Math.max(0, progress.positivePoints - progress.treatPointsUsed)
-  const completedIds = new Set(progress.completedActivities.map((completed) => completed.activityId))
+  const planItems = (initialSummary?.items ?? []).filter((item) => item.status !== 'replaced')
+  const completedItemsCount = initialSummary?.completedItemsCount ?? 0
+  const pendingItemsCount = initialSummary?.pendingItemsCount ?? 0
+  const totalPlanItems = completedItemsCount + pendingItemsCount
+  const completionRate = totalPlanItems > 0 ? Math.round((completedItemsCount / totalPlanItems) * 100) : 0
 
-  const plannedActivities = demoPlan
-    .map((item) => ({ ...item, activity: allActivities.find((activity) => activity.id === item.activityId) }))
-    .filter((item): item is PlannedActivity => Boolean(item.activity))
+  const availablePoints = initialSummary?.availablePoints ?? 0
+  const completedPoints = initialSummary?.completedPoints ?? 0
+  const redeemedPoints = initialSummary?.redeemedPoints ?? 0
 
-  const completionRate = plannedActivities.length
-    ? Math.round((plannedActivities.filter((item) => completedIds.has(item.activity.id)).length / plannedActivities.length) * 100)
-    : 0
+  const allActivities = initialActivities.map(toActivityShape)
+  const positiveActivities = allActivities.filter((a) => a.type === 'positive')
+  const treatActivities = allActivities.filter((a) => a.type === 'treat')
 
   const nextReward = treatActivities.find((reward) => reward.points <= availablePoints) ?? treatActivities[0]
 
-  const getCompletedCount = (activityId: string) => {
-    return progress.completedActivities.filter((completed) => completed.activityId === activityId).length
-  }
-
-  const groupByCategory = (activities: Activity[]) => {
-    return activities.reduce(
+  const groupByCategory = (activities: Activity[]) =>
+    activities.reduce(
       (acc, activity) => {
         if (!acc[activity.category]) acc[activity.category] = []
         acc[activity.category].push(activity)
@@ -95,10 +92,20 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
       },
       {} as Record<string, Activity[]>,
     )
-  }
 
   const positiveByCategory = groupByCategory(positiveActivities)
   const treatsByCategory = groupByCategory(treatActivities)
+
+  const handleCompletePlanItem = (planItemId: string) => {
+    startTransition(async () => {
+      await fetch('/api/today/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ planItemId }),
+      })
+      router.refresh()
+    })
+  }
 
   const handleSignOut = async () => {
     const supabase = createClient()
@@ -134,12 +141,8 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={resetDay}>
-                  <RotateCcw className="mr-2 h-4 w-4" />
-                  Reset demo day
-                </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleSignOut}>Sign out demo user</DropdownMenuItem>
+                <DropdownMenuItem onClick={handleSignOut}>Sign out</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
@@ -194,7 +197,7 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
                 />
               </div>
               <p className="text-sm text-muted-foreground">
-                {progress.completedActivities.length} completions logged today. Next reward:{' '}
+                {completedItemsCount} completions logged today. Next reward:{' '}
                 <span className="font-medium text-foreground">{nextReward?.name ?? 'choose one'}</span>
               </p>
             </div>
@@ -202,48 +205,85 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
         </section>
 
         <section className="grid gap-6 lg:grid-cols-[0.95fr_1.05fr]">
-          <BalanceMeter />
+          <BalanceMeter
+            availablePoints={availablePoints}
+            completedPoints={completedPoints}
+            redeemedPoints={redeemedPoints}
+          />
 
           <Card className="p-5">
             <div className="mb-4 flex items-center justify-between gap-3">
               <div>
                 <p className="text-sm font-medium text-primary">Today</p>
                 <h2 className="font-serif text-2xl font-semibold text-foreground">Coach plan</h2>
-                <p className="text-sm text-muted-foreground">Duration-based actions. No fixed schedule.</p>
+                <p className="text-sm text-muted-foreground">
+                  {initialSummary?.agentSummary ?? 'Duration-based actions. No fixed schedule.'}
+                </p>
               </div>
               <Target className="h-6 w-6 text-primary" />
             </div>
 
-            <div className="space-y-3">
-              {plannedActivities.map((item, index) => {
-                const done = completedIds.has(item.activity.id)
-                return (
-                  <button
-                    key={item.activity.id}
-                    onClick={() => !done && completeActivity(item.activity.id, item.activity.duration)}
-                    className="flex w-full items-start gap-3 rounded-2xl border border-border bg-background/60 p-3 text-left transition hover:border-primary/40 hover:bg-primary/5"
-                  >
-                    <div className={done ? 'mt-0.5 text-positive' : 'mt-0.5 text-muted-foreground'}>
-                      {done ? <CheckCircle2 className="h-5 w-5" /> : <span className="flex h-5 w-5 items-center justify-center rounded-full border text-xs">{index + 1}</span>}
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="font-medium text-foreground">{item.label}</p>
-                        <span className="rounded-full bg-positive/10 px-2 py-0.5 text-xs font-medium text-positive">
-                          +{item.activity.points} pts
-                        </span>
-                        {item.activity.duration && (
-                          <span className="text-xs text-muted-foreground">{item.activity.duration} min</span>
+            {planItems.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-8 text-center">
+                <p className="text-sm text-muted-foreground">No plan yet for today.</p>
+                <Button size="sm" variant="outline" onClick={scrollToCoachChat}>
+                  <MessageCircle className="mr-2 h-4 w-4" />
+                  Ask coach to plan your day
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {planItems.map((item, index) => {
+                  const done = item.status === 'completed'
+                  return (
+                    <button
+                      key={item.id}
+                      disabled={done || isPending}
+                      onClick={() => !done && handleCompletePlanItem(item.id)}
+                      className="flex w-full items-start gap-3 rounded-2xl border border-border bg-background/60 p-3 text-left transition hover:border-primary/40 hover:bg-primary/5 disabled:cursor-default disabled:opacity-70"
+                    >
+                      <div className={done ? 'mt-0.5 text-positive' : 'mt-0.5 text-muted-foreground'}>
+                        {done ? (
+                          <CheckCircle2 className="h-5 w-5" />
+                        ) : (
+                          <span className="flex h-5 w-5 items-center justify-center rounded-full border text-xs">{index + 1}</span>
                         )}
                       </div>
-                      <p className="mt-1 text-sm text-muted-foreground">{item.note}</p>
-                    </div>
-                  </button>
-                )
-              })}
-            </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-medium text-foreground">{item.title}</p>
+                          <span className="rounded-full bg-positive/10 px-2 py-0.5 text-xs font-medium text-positive">
+                            +{item.points} pts
+                          </span>
+                          {item.durationMinutes && (
+                            <span className="text-xs text-muted-foreground">{item.durationMinutes} min</span>
+                          )}
+                        </div>
+                        {item.rationale && <p className="mt-1 text-sm text-muted-foreground">{item.rationale}</p>}
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
           </Card>
         </section>
+
+        {initialSummary?.recentCheckIn && (
+          <section>
+            <Card className="border-primary/15 bg-primary/5 p-4">
+              <div className="flex items-start gap-3">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <MessageCircle className="h-4 w-4" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-primary">Latest check-in · {initialSummary.recentCheckIn.intent}</p>
+                  <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{initialSummary.recentCheckIn.message}</p>
+                </div>
+              </div>
+            </Card>
+          </section>
+        )}
 
         <section>
           <ChatPanel displayName={displayName} />
@@ -279,7 +319,7 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
                   <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">{category}</h3>
                   <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                     {activities.map((activity) => (
-                      <ActivityCard key={activity.id} activity={activity} completedCount={getCompletedCount(activity.id)} />
+                      <ActivityCard key={activity.id} activity={activity} availablePoints={availablePoints} />
                     ))}
                   </div>
                 </motion.div>
@@ -306,7 +346,7 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
                   <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">{category}</h3>
                   <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                     {activities.map((activity) => (
-                      <ActivityCard key={activity.id} activity={activity} completedCount={getCompletedCount(activity.id)} />
+                      <ActivityCard key={activity.id} activity={activity} availablePoints={availablePoints} />
                     ))}
                   </div>
                 </motion.div>
@@ -314,19 +354,6 @@ export function Dashboard({ profileId, displayName }: DashboardProps) {
             </TabsContent>
           </Tabs>
         </section>
-
-        {customActivities.length > 0 && (
-          <Card className="p-5">
-            <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Custom items</h3>
-            <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {customActivities
-                .filter((activity) => activity.type === activeTab)
-                .map((activity) => (
-                  <ActivityCard key={activity.id} activity={activity} completedCount={getCompletedCount(activity.id)} />
-                ))}
-            </div>
-          </Card>
-        )}
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary

- Dashboard reads plan, activities, and wallet from Supabase instead of Zustand
- `GET /api/activities` — new endpoint for `user_activities` + `rewards` from Supabase (with `type: positive | treat`)
- `POST /api/today/complete` — new endpoint to complete plan items via domain service
- `page.tsx` fetches `getTodaySummary()` + activities in parallel server-side and passes as initial props
- `BalanceMeter` now accepts wallet totals as props (no Zustand)
- Plan items come from `daily_plan_items` via `getTodaySummary()`; plan item completion calls the API then `router.refresh()`
- Recent check-in from `getTodaySummary()` is surfaced in the dashboard
- Marketplace activity list comes from Supabase `user_activities` + `rewards`

## Test plan

- [ ] Log in as a user who has completed onboarding
- [ ] Verify plan section shows items from Supabase (not hardcoded demo plan)
- [ ] Click a plan item — it should mark as done and the wallet should update after refresh
- [ ] Verify BalanceMeter shows correct points from Supabase wallet_transactions
- [ ] Verify marketplace shows activities from user_activities + rewards tables
- [ ] Verify recent check-in card appears if there are check-ins
- [ ] Verify empty state appears when no plan exists yet

Closes #17