### PR TITLE
fix(copy): rename balance-flow-storage key to habitquest-storage

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -141,7 +141,7 @@ export const useAppStore = create<AppState>()(
       },
     }),
     {
-      name: 'balance-flow-storage',
+      name: 'habitquest-storage',
     }
   )
 )


### PR DESCRIPTION
Closes #19

## Summary

- Renamed the Zustand persist key from `balance-flow-storage` to `habitquest-storage` in [`lib/store.ts`](lib/store.ts)
- All other user-facing copy was already using HabitQuest; this was the only remaining BalanceFlow reference in code

## Changes

| File | Change |
|------|--------|
| `lib/store.ts` | Persist key renamed from `balance-flow-storage` → `habitquest-storage` |

## Acceptance criteria

- [x] No main copy uses BalanceFlow
- [x] No main copy claims guaranteed hormone regulation
- [x] Metadata and onboarding use HabitQuest and responsible framing